### PR TITLE
optimised code for direct access of keys/array

### DIFF
--- a/array-loop.js
+++ b/array-loop.js
@@ -32,9 +32,9 @@ module.exports = function (RED) {
         node.resetValue = n.resetValue;
 
         this.on('input', function (msg) {
-            let key = RED.util.evaluateNodeProperty(node.key, node.keyType, node, msg);
-            let array = RED.util.evaluateNodeProperty(node.array, node.arrayType, node, msg);
-
+            let key = msg[node.key]
+            let array = msg[node.array]
+            
             if (!Array.isArray(array)) {
                 let text = RED._('array-loop.errors.arraynotarray') + array;
                 sendErrorMessage(node, text);


### PR DESCRIPTION
I was looping around 5k records using this node and found  that the loop was executed slowly and some time crashed nodered because of memory consumption. With deep nodejs inspect analysis I found that much of the time was taken by the `RED.util.evaluateNodeProperty` function. It actually added too much code to the main stack for getting the value of the field. I changed it to direct access. Please check if this change is suitable for merge. 
I further tested this for 10k records & there was no crash this time.